### PR TITLE
Missing an include for cstdint

### DIFF
--- a/include/Aether/utils/Types.hpp
+++ b/include/Aether/utils/Types.hpp
@@ -3,6 +3,7 @@
 
 #include "Aether/types/Colour.hpp"
 #include <functional>
+#include <cstdint>
 
 namespace Aether {
     /**


### PR DESCRIPTION
I was compiling Triplayer and had an error related to the include of cstdint missing in the Types.h file. 